### PR TITLE
Add setters for PandasData and MatchMSData

### DIFF
--- a/RIAssigner/data/MatchMSData.py
+++ b/RIAssigner/data/MatchMSData.py
@@ -35,8 +35,12 @@ class MatchMSData(Data):
         raise NotImplementedError()
 
     @retention_indices.setter
-    def retention_indices(self, value: Iterable[int]):
-        raise NotImplementedError()
+    def retention_indices(self, values: Iterable[int]):
+        if len(values) == len(self._spectra):
+            for value_idx in range(len(values)):
+                self._spectra[value_idx].set(key="retentionindex", value=values[value_idx])
+        else:
+            raise ValueError("There is different numbers of computed indices and peaks.")
 
 
 def safe_read_rt(spectrum) -> Optional[float]:

--- a/RIAssigner/data/MatchMSData.py
+++ b/RIAssigner/data/MatchMSData.py
@@ -37,8 +37,7 @@ class MatchMSData(Data):
     @retention_indices.setter
     def retention_indices(self, values: Iterable[int]):
         if len(values) == len(self._spectra):
-            for value_idx in range(len(values)):
-                self._spectra[value_idx].set(key="retentionindex", value=values[value_idx])
+            list(map(_assign_ri_value, self._spectra, values))
         else:
             raise ValueError("There is different numbers of computed indices and peaks.")
 
@@ -59,3 +58,7 @@ def _spectrum_has_rt(spectrum: Spectrum) -> bool:
     if not has_key:
         return False
     return True
+
+
+def _assign_ri_value(spectrum: object, value: int):
+    spectrum.set(key="retentionindex", value=value)

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -11,14 +11,15 @@ class PandasData(Data):
 
     def read(self, filename: str):
         self._data = read_csv(filename)
-        self._set_rt_index()
+        self._set_rt_index_n_position()
         self._set_carbon_number_index()
 
     def _set_carbon_number_index(self):
         self._carbon_number_index = get_first_common_element(self._data.columns, self._carbon_number_column_names)
 
-    def _set_rt_index(self):
+    def _set_rt_index_n_position(self):
         self._rt_index = get_first_common_element(self._data.columns, self._rt_column_names)
+        self._rt_position = self._data.columns.tolist().index(self._rt_index)
 
     @property
     def retention_times(self) -> Iterable[int]:
@@ -33,6 +34,7 @@ class PandasData(Data):
     @retention_indices.setter
     def retention_indices(self, value: Iterable[int]):
         if len(value) == len(self._data):
-            self._data["retention_index"] = value
+            self._ri_position = self._rt_position + 1  
+            self._data.insert(loc=self._ri_col_position, column="retention_index", value=value)
         else:
             raise ValueError("There is different numbers of computed indices and peaks.")

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -32,4 +32,7 @@ class PandasData(Data):
 
     @retention_indices.setter
     def retention_indices(self, value: Iterable[int]):
-        raise NotImplementedError()
+        if len(value) == len(self._data):
+            self._data["retention_index"] = value
+        else:
+            raise ValueError("There is different numbers of computed indices and peaks.")

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -29,6 +29,8 @@ class PandasData(Data):
     def retention_indices(self):
         if self._carbon_number_index is not None:
             return self._data[self._carbon_number_index] * 10
+        elif "retention_index" in self._data.columns:
+            return self._data["retention_index"]
         raise KeyError("Dataset does not contain retention indices!")
 
     @retention_indices.setter

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -34,9 +34,9 @@ class PandasData(Data):
         raise KeyError("Dataset does not contain retention indices!")
 
     @retention_indices.setter
-    def retention_indices(self, value: Iterable[int]):
-        if len(value) == len(self._data):
+    def retention_indices(self, values: Iterable[int]):
+        if len(values) == len(self._data):
             self._ri_position = self._rt_position + 1  
-            self._data.insert(loc=self._ri_position, column="retention_index", value=value)
+            self._data.insert(loc=self._ri_position, column="retention_index", value=values)
         else:
             raise ValueError("There is different numbers of computed indices and peaks.")

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -40,7 +40,7 @@ class PandasData(Data):
     @property
     def retention_indices(self):
         if not self._data[self._ri_index].isnull().all():
-            return self._data[self._rt_index]
+            return self._data[self._ri_index]
         else:
             raise KeyError("Dataset does not contain retention indices!")
 

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -35,6 +35,6 @@ class PandasData(Data):
     def retention_indices(self, value: Iterable[int]):
         if len(value) == len(self._data):
             self._ri_position = self._rt_position + 1  
-            self._data.insert(loc=self._ri_col_position, column="retention_index", value=value)
+            self._data.insert(loc=self._ri_position, column="retention_index", value=value)
         else:
             raise ValueError("There is different numbers of computed indices and peaks.")

--- a/tests/test_data_PandasData.py
+++ b/tests/test_data_PandasData.py
@@ -46,7 +46,7 @@ def test_read_rts(filename_csv, retention_times):
     numpy.testing.assert_array_almost_equal(actual, expected)
 
 
-@pytest.mark.parametrize("filename, expected", [["Alkanes_20210325.csv", range(110, 410, 10)]])
+@pytest.mark.parametrize("filename, expected", [["Alkanes_20210325.csv", range(1100, 4100, 100)]])
 def test_read_ris(filename, expected):
     filename = os.path.join(here, "data", "csv", filename)
     data = PandasData(filename)


### PR DESCRIPTION
#4 
**PandasData:**
+ Changed `_set_rt_index()` to `_set_rt_index_n_position()`. Besides fetching RT column name it now fetches its numerical index. 
+ Changed getter for RIs `retention_indices()` to return column with RIs if exists.
+ Implemented setter for `retention_indices()` - after comparing RIs list/tuple length to length of features puts RIs in a new column next to RTs.

**MatchMSData:**
+ Implemented setter for `retention_indices()` - after after comparing RIs list/tuple length to length of features adds RI to metadata attribute of Spectra object. After exporting metadata back to `.msp` **RI** will appear as the last item of metadata. I'd like to put it after **RT**, but don't have an idea yet how to do that without cryptic code like [this](https://stackoverflow.com/questions/56982009/how-to-rearrange-the-order-of-dictionary-keys).

Closes #4