### PR TITLE
Add writers to PandasData and MatchMSData classes

### DIFF
--- a/RIAssigner/data/Data.py
+++ b/RIAssigner/data/Data.py
@@ -15,6 +15,10 @@ class Data(ABC):
     def read(self, filename):
         ...
 
+    @abstractmethod
+    def write(self, filename):
+        ...
+
     @property
     def filename(self):
         return self._filename

--- a/RIAssigner/data/MatchMSData.py
+++ b/RIAssigner/data/MatchMSData.py
@@ -1,5 +1,6 @@
 from .Data import Data
 from matchms import Spectrum
+from matchms.exporting import save_as_msp
 from matchms.importing import load_from_msp
 from typing import Optional, Iterable
 
@@ -17,6 +18,9 @@ class MatchMSData(Data):
 
         self._read_retention_times()
         self._read_retention_indices()
+
+    def write(self, filename: str):
+        save_as_msp(self._spectra, filename)
 
     def _read_spectra(self, filename):
         if filename.endswith('.msp'):

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -19,6 +19,9 @@ class PandasData(Data):
         self._init_ri_indices()
         self._sort_by_rt()
 
+    def write(self, filename: str):
+        self._data.to_csv(filename, index=False)
+
     def _init_carbon_number_index(self):
         """ Find key of carbon number column and store it. """
         self._carbon_number_index = get_first_common_element(self._data.columns, self._carbon_number_column_names)

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - numpy
-  - matchms >=0.8.2
+  - matchms >=0.9.0
   - pip
   - pandas
   - prospector

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -5,6 +5,6 @@ channels:
   - defaults
 dependencies:
   - numpy
-  - matchms >=0.8.2
+  - matchms >=0.9.0
   - pandas
   - python >=3.7,<3.9

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - setuptools
   run:
     - numpy
-    - matchms >=0.8.2
+    - matchms >=0.9.0
     - pip
     - pandas
     - python >=3.7,<3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ mccabe==0.6.1
 more-itertools==8.7.0
 mypy-extensions==0.4.3
 numpy==1.20.2
-matchms==0.8.2
+matchms==0.9.0
 packaging==20.9
 pandas==1.2.3
 pep8-naming==0.10.0


### PR DESCRIPTION
* Added writers to Data classes
   * MatchMSData object is to be stored on disk in `.msp` format
   *  PandasData object is to be stored in `.csv`
* Incremented **matchms** version in requirements and build recipes to 0.9.0 to support `save_as_msp` method

Closes #10, closes #11 