### PR TITLE
Changed CI actions to be triggered on same events and to call tests in the same way

### DIFF
--- a/.github/workflows/anaconda.yml
+++ b/.github/workflows/anaconda.yml
@@ -2,9 +2,7 @@ name: Anaconda Build
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,9 @@
 name: Python Package using Conda
 
-on: [push]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build-linux:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -33,5 +33,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        conda install pytest
+        conda install pytest pytest-cov
         pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Test with pytest
       run: |
         conda install pytest
-        pytest
+        pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml


### PR DESCRIPTION
Fixes #32 

The CI actions are now calling tests in the same way (using coverage) and are triggered on all pushes to all branches.