### PR TITLE
Implemented tests for matchms writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- data/MatchMSData.py: `_assign_ri_value` now converts all values to float and stores them as string in metadata field
+- data/MatchMSData.py `_read_retention_indices` now calls retention_indices property setter to store values
 ### Removed
 ## [0.1.0] - 2021-07-12
 ### Added

--- a/RIAssigner/data/MatchMSData.py
+++ b/RIAssigner/data/MatchMSData.py
@@ -53,7 +53,7 @@ class MatchMSData(Data):
         return self._retention_indices
 
     @retention_indices.setter
-    def retention_indices(self, values: Iterable[int]):
+    def retention_indices(self, values: Iterable[Data.RetentionIndexType]):
         """ Set retention indices. """
         if len(values) == len(self._spectra):
             self._retention_indices = values

--- a/RIAssigner/data/MatchMSData.py
+++ b/RIAssigner/data/MatchMSData.py
@@ -36,7 +36,7 @@ class MatchMSData(Data):
 
     def _read_retention_indices(self):
         """ Read retention indices from spectrum metadata. """
-        self._retention_indices = [safe_read_key(spectrum, 'retentionindex') for spectrum in self._spectra]
+        self.retention_indices = [safe_read_key(spectrum, 'retentionindex') for spectrum in self._spectra]
 
     def _sort_spectra_by_rt(self):
         """ Sort objects (peaks) in spectra list by their retention times. """
@@ -96,4 +96,6 @@ def _assign_ri_value(spectrum: Spectrum, value: Data.RetentionIndexType):
         spectrum (Spectrum): Spectrum to add RI to
         value (Data.RetentionIndexType): RI to be added to Spectrum
     """
-    spectrum.set(key='retentionindex', value=value)
+    if value is not None:
+        retention_index = ('%f' % float(value)).rstrip('0').rstrip('.')
+        spectrum.set(key='retentionindex', value=retention_index)

--- a/tests/test_data_MatchMSData.py
+++ b/tests/test_data_MatchMSData.py
@@ -2,10 +2,10 @@ import os
 
 import numpy
 import pytest
+from matchms.exporting import save_as_msp
 from matchms.importing import load_from_msp
 
-from .builders.MatchMSDataBuilder import MatchMSDataBuilder
-
+from tests.builders.MatchMSDataBuilder import MatchMSDataBuilder
 
 here = os.path.abspath(os.path.dirname(__file__))
 testdata_dir = os.path.join(here, 'data', 'msp')
@@ -73,3 +73,26 @@ def test_read_ris(filename, expected):
 
     actual = data.retention_indices[:10]
     numpy.testing.assert_array_almost_equal(actual, expected)
+
+
+@pytest.mark.parametrize("filename", ["PFAS_added_rt.msp"])
+def test_basic_write(filename, tmp_path):
+    # TODO: Reafactor with load_test_file
+    filepath = os.path.join(testdata_dir, filename)
+    data = MatchMSDataBuilder().with_filename(filepath).build()
+
+    outpath = os.path.join(tmp_path, "riassigner.msp")
+    data.write(outpath)
+
+    spectra = list(load_from_msp(filepath))
+    spectra.sort(key=lambda spectrum: float(spectrum.get('retentiontime')))
+
+    expected_outpath = os.path.join(tmp_path, "matchms.msp")
+    save_as_msp(spectra, expected_outpath)
+
+    with open(expected_outpath, 'r') as file:
+        expected = file.readlines()
+    with open(outpath, 'r') as file:
+        actual = file.readlines()
+
+    assert expected == actual

--- a/tests/test_data_MatchMSData.py
+++ b/tests/test_data_MatchMSData.py
@@ -75,7 +75,7 @@ def test_read_ris(filename, expected):
     numpy.testing.assert_array_almost_equal(actual, expected)
 
 
-@pytest.mark.parametrize("filename", ["PFAS_added_rt.msp"])
+@pytest.mark.parametrize("filename", ["PFAS_added_rt.msp", "recetox_gc-ei_ms_20201028.msp"])
 def test_basic_write(filename, tmp_path):
     # TODO: Reafactor with load_test_file
     filepath = os.path.join(testdata_dir, filename)


### PR DESCRIPTION
Implemented tests for `write` method for MatchMSData class and fixed storage of RI field to string datatype. This might also be relevant for #47.

Closes #16 
