### PR TITLE
fix exception string comparisons

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+xunit-result.xml
 
 # Translations
 *.mo

--- a/tests/test_compute_ComputationMethod.py
+++ b/tests/test_compute_ComputationMethod.py
@@ -21,4 +21,4 @@ def test_abc():
 
     message = exception.value.args[0]
     assert exception.typename == "TypeError"
-    assert str(message).startswith("Can't instantiate abstract class ComputationMethod with abstract methods")
+    assert str(message).startswith("Can't instantiate abstract class ComputationMethod with abstract method")


### PR DESCRIPTION
The actual exception message reads: 
```
"Can't instantiate abstract class ComputationMethod with abstract method compute"
```
Both for py3.8 and 3.9 in my testing. Not sure when it passes.

As a side note the benefit of testing system strings for equality seems doubtful. I don't think they can be relied upon.