### PR TITLE
Fix bug when reading tsv files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.3.1] - 2021-12-9
+### Changed
+- data/PandasData.py: `_read_into_dataframe()` now deduces a proper delimiter via python's [`csv.Sniffer`](https://docs.python.org/3/library/csv.html#csv.Sniffer) class. [#73](https://github.com/RECETOX/RIAssigner/pull/73)
+
 ## [0.3.0] - 2021-09-03
 ### Added
 - __main__.py + cli/LoadDataAction.py: Added required passing of filetype and rt unit. [#64](https://github.com/RECETOX/RIAssigner/issues/64) [#67](https://github.com/RECETOX/RIAssigner/issues/67) [#68](https://github.com/RECETOX/RIAssigner/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1] - 2021-12-9
 ### Changed
-- data/PandasData.py: `_read_into_dataframe()` now deduces a proper delimiter via python's [`csv.Sniffer`](https://docs.python.org/3/library/csv.html#csv.Sniffer) class. [#73](https://github.com/RECETOX/RIAssigner/pull/73)
+- data/PandasData.py: `_read_into_dataframe()` now deduces a proper delimiter via Python's [`csv.Sniffer`](https://docs.python.org/3/library/csv.html#csv.Sniffer) class. [#73](https://github.com/RECETOX/RIAssigner/pull/73)
 
 ## [0.3.0] - 2021-09-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ from RIAssigner.compute import Kovats
 from RIAssigner.data import MatchMSData, PandasData
 
 # Load reference & query data
-query = PandasData("../tests/data/csv/aplcms_aligned_peaks.csv")
-reference = MatchMSData("../tests/data/msp/Alkanes_20210325.msp", rt_unit="min")
+query = PandasData("../tests/data/csv/aplcms_aligned_peaks.csv", "csv", rt_unit="seconds")
+reference = MatchMSData("../tests/data/msp/Alkanes_20210325.msp", "msp", rt_unit="min")
 
 # Compute RI and write it back to file
 query.retention_indices = Kovats().compute(query, reference)

--- a/RIAssigner/data/PandasData.py
+++ b/RIAssigner/data/PandasData.py
@@ -25,8 +25,7 @@ class PandasData(Data):
     def _read_into_dataframe(self):
         """ Read the data from file into dataframe. """
         if(self._filetype in ['csv', 'tsv']):
-            separator = define_separator(self._filename)
-            self._data = read_csv(self._filename, sep=separator)
+            self._data = read_csv(self._filename, sep=None, engine="python")
         else:
             raise NotImplementedError("File formats different from ['csv', 'tsv'] are not implemented yet.")
 

--- a/doc/example_usage.ipynb
+++ b/doc/example_usage.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "code",
    "execution_count": 1,
    "source": [
-    "from RIAssigner.compute import Kovats\r\n",
-    "from RIAssigner.data import MatchMSData, PandasData\r\n",
-    "\r\n",
-    "# Load test data and init computation method\r\n",
-    "query = PandasData(\"../tests/data/csv/aplcms_aligned_peaks.csv\")\r\n",
-    "reference = MatchMSData(\"../tests/data/msp/Alkanes_20210325.msp\", rt_unit=\"min\")\r\n",
+    "from RIAssigner.compute import Kovats\n",
+    "from RIAssigner.data import MatchMSData, PandasData\n",
+    "\n",
+    "# Load test data and init computation method\n",
+    "query = PandasData(\"../tests/data/csv/aplcms_aligned_peaks.csv\", \"csv\", rt_unit=\"seconds\")\n",
+    "reference = MatchMSData(\"../tests/data/msp/Alkanes_20210325.msp\", \"msp\", rt_unit=\"min\")\n",
     "method = Kovats()"
    ],
    "outputs": [],


### PR DESCRIPTION
* set `sep=None` in `read_csv(...)` to let python's [csv.Sniffer](https://docs.python.org/3/library/csv.html#csv.Sniffer) parse the file and identify a delimiter
* otherwise `define_separator(...)` would parse the Galaxy's `.dat` file and based on that extension return a comma as a proper delimiter for all `PandasData` objects

Closes #72 