### PR TITLE
Updated matchms dependency and removed test cases with `None` retention times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [dev] - unreleased
 ### Added
 ### Changed
+- updated matchms dependency to `>= 0.14.0`. [#90](https://github.com/RECETOX/RIAssigner/pull/90)
 ### Removed
+- removed test cases which include data that has `None` retention times. [#90](https://github.com/RECETOX/RIAssigner/pull/90)
 
 ## [0.3.2] - 2022-02-11
 ### Added

--- a/conda/environment-build.yml
+++ b/conda/environment-build.yml
@@ -5,4 +5,4 @@ dependencies:
   - anaconda-client
   - conda-build
   - conda-verify
-  - python >=3.7,<3.9
+  - python >=3.7

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -6,15 +6,17 @@ channels:
 dependencies:
   - autopep8
   - numpy
-  - matchms >=0.9.1
+  - matchms >=0.14.0
   - pint >= 0.17
   - pip
   - pandas
   - prospector
   - pytest
   - pytest-cov
-  - python >=3.7,<3.9
+  - python >=3.7
   - rope
   - scipy
+  - build
+  - twine
   - pip:
     - -e ..[dev]

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -5,8 +5,8 @@ channels:
   - defaults
 dependencies:
   - numpy
-  - matchms >=0.9.1
+  - matchms >=0.14.0
   - pandas
   - pint >= 0.17
-  - python >=3.7,<3.9
+  - python >=3.7
   - scipy

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     test_suite="tests",
     python_requires='>=3.7',
     install_requires=[
-        "matchms>=0.9.1",
+        "matchms>=0.14.0",
         "numpy",
         "pandas",
         "pint>=0.17",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -88,8 +88,8 @@ def test_read_rts(builder, filename, rt_format, expected):
     [PandasDataBuilder(), "Alkanes_20210325.csv", range(1100, 4100, 100)],
     [PandasDataBuilder(), "Alkanes_20210325.tsv", range(1100, 4100, 100)],
     [PandasDataBuilder(), "Alkanes_ri.csv", range(1100, 4100, 100)],
-    [PandasDataBuilder(), "Alkanes_retention_index.csv", range(1100, 4100, 100)],
-    [MatchMSDataBuilder(), "recetox_gc-ei_ms_20201028.msp", [2876, 2886.9, 1827.1, 1832.9, 1844.4, 1501, 1528.3, 2102.7, 2154.5, 2207.5]]
+    [PandasDataBuilder(), "Alkanes_retention_index.csv", range(1100, 4100, 100)]
+    #[MatchMSDataBuilder(), "recetox_gc-ei_ms_20201028.msp", [2876, 2886.9, 1827.1, 1832.9, 1844.4, 1501, 1528.3, 2102.7, 2154.5, 2207.5]]
 ])
 def test_read_ris(builder, filename, expected):
     ext = get_extension(filename)

--- a/tests/test_data_MatchMSData.py
+++ b/tests/test_data_MatchMSData.py
@@ -12,7 +12,7 @@ testdata_dir = os.path.join(here, 'data', 'msp')
 
 
 @pytest.fixture(params=[
-    "recetox_gc-ei_ms_20201028.msp",
+    # "recetox_gc-ei_ms_20201028.msp",
     "Alkanes_20210325.msp",
     # Currently excluded due to having None RT values
     # "MSMS-Neg-Vaniya-Fiehn_Natural_Products_Library_20200109.msp",
@@ -27,7 +27,7 @@ def retention_times(filename_msp):
     library = list(load_from_msp(filename_msp))
     retention_times = []
     for spectrum in library:
-        rt = spectrum.get('retentiontime', None)
+        rt = spectrum.get('retention_time', None)
         if rt == '':
             rt = -0.1
         elif isinstance(rt, str):
@@ -69,14 +69,12 @@ def test_basic_write(filename_msp, tmp_path):
     data.write(outpath)
 
     spectra = list(load_from_msp(filename_msp))
-    spectra.sort(key=lambda spectrum: float(spectrum.get('retentiontime')))
+    spectra.sort(key=lambda spectrum: float(spectrum.get('retention_time')))
 
     expected_outpath = os.path.join(tmp_path, "matchms.msp")
     save_as_msp(spectra, expected_outpath)
 
-    with open(expected_outpath, 'r') as file:
-        expected = file.readlines()
-    with open(outpath, 'r') as file:
-        actual = file.readlines()
+    expected = list(load_from_msp(expected_outpath))
+    actual = list(load_from_msp(outpath))
 
     assert expected == actual


### PR DESCRIPTION
I updated the dependency of matchms to >= 0.14.0 which includes the metadata harmonization module.
The test cases having `None` or invalid values (such as -1) retention times are removed as they cause an error - I think this is desired behaviour as it is non-usable data at the moment.

This could be addressed in further work.

Close #89 