### PR TITLE
Fix dependencies (pint and numpy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [0.3.4] - 2023-02-21
+### Changed
+- pinned pint >=0.17,<0.20 and matchms >=0.14.0,<0.18.0 for dependency issues
+
 ## [0.3.3] - 2022-07-22
 ### Added
 ### Changed

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - autopep8
   - numpy
-  - matchms >=0.14.0
+  - matchms >=0.14.0,<0.18.0
   - pint >=0.17,<0.20
   - pip
   - pandas

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - autopep8
   - numpy
   - matchms >=0.14.0
-  - pint >= 0.17
+  - pint >=0.17,<0.20
   - pip
   - pandas
   - prospector

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - numpy
   - matchms >=0.14.0
   - pandas
-  - pint >= 0.17
+  - pint >=0.17,<0.20
   - python >=3.7
   - scipy

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - numpy
-  - matchms >=0.14.0
+  - matchms >=0.14.0,<0.18.0
   - pandas
   - pint >=0.17,<0.20
   - python >=3.7

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "matchms>=0.14.0",
         "numpy",
         "pandas",
-        "pint>=0.17",
+        "pint>=0.17,<0.20",
         "scipy"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     test_suite="tests",
     python_requires='>=3.7',
     install_requires=[
-        "matchms>=0.14.0",
+        "matchms>=0.14.0,<0.18.0",
         "numpy",
         "pandas",
         "pint>=0.17,<0.20",


### PR DESCRIPTION
This PR pinned `pint >=0.17,<0.20` and `matchms >=0.14.0,<0.18.0` for dependency issues.

Close #96.